### PR TITLE
Add tests to ActivityTabs

### DIFF
--- a/packages/client/.storybook/config.js
+++ b/packages/client/.storybook/config.js
@@ -16,13 +16,13 @@ const theme = {
 
 addDecorator(withKnobs());
 addDecorator(StoryRouter());
-addDecorator(muiTheme([theme]));
 addDecorator(storyFn => (
   <>
     <CssBaseline />
     {storyFn()}
   </>
 ));
+addDecorator(muiTheme([theme]));
 addDecorator(Story => <Story />);
 
 // automatically import all files ending in *.stories.{ts,tsx}

--- a/packages/client/.storybook/preview-head.html
+++ b/packages/client/.storybook/preview-head.html
@@ -1,0 +1,4 @@
+<link
+  rel="stylesheet"
+  href="https://fonts.googleapis.com/icon?family=Material+Icons"
+/>

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -44,7 +44,7 @@
     "use-sound": "^1.0.1"
   },
   "devDependencies": {
-    "@storybook/addon-actions": "^5.3.0",
+    "@storybook/addon-actions": "^5.3.18",
     "@storybook/addon-knobs": "^5.3.18",
     "@storybook/addon-links": "^5.3.0",
     "@storybook/addon-storyshots": "^5.3.0",

--- a/packages/client/src/__snapshots__/Storyshots.test.ts.snap
+++ b/packages/client/src/__snapshots__/Storyshots.test.ts.snap
@@ -10,13 +10,13 @@ Object {
           style="height: 100vh; width: 100%; background: gray;"
         >
           <div
-            class="MuiBox-root MuiBox-root-160"
+            class="MuiBox-root MuiBox-root-268"
           >
             <div
-              class="MuiBox-root MuiBox-root-161"
+              class="MuiBox-root MuiBox-root-269"
             >
               <div
-                class="div-root-162"
+                class="div-root-270"
               >
                 <h5
                   class="MuiTypography-root MuiTypography-h5 MuiTypography-colorInherit MuiTypography-alignCenter"
@@ -36,7 +36,7 @@ Object {
                   class="MuiTypography-root MuiTypography-h6 MuiTypography-colorPrimary MuiTypography-alignCenter"
                 >
                   <div
-                    class="MuiBox-root MuiBox-root-206 Styled(MuiBox)-root-205"
+                    class="MuiBox-root MuiBox-root-314 Styled(MuiBox)-root-313"
                     title="Copied!"
                   >
                     http://localhost/
@@ -45,34 +45,34 @@ Object {
               </div>
             </div>
             <div
-              class="div-root-207"
+              class="div-root-315"
             >
               <div
-                class="MuiPaper-root MuiCard-root WithStyles(ForwardRef(Card))-root-208 WithStyles(ForwardRef(Card))-root-209 MuiPaper-elevation10 MuiPaper-rounded"
+                class="MuiPaper-root MuiCard-root WithStyles(ForwardRef(Card))-root-316 WithStyles(ForwardRef(Card))-root-317 MuiPaper-elevation10 MuiPaper-rounded"
               >
                 <div
-                  class="MuiBox-root MuiBox-root-239"
+                  class="MuiBox-root MuiBox-root-347"
                 >
                   <div
-                    class="div-root-246"
+                    class="div-root-354"
                   >
                     <div
-                      class="div-root-247"
+                      class="div-root-355"
                     >
                       <video
                         autoplay=""
-                        class="makeStyles-mirroredVideo-241 makeStyles-video-240  "
+                        class="makeStyles-mirroredVideo-349 makeStyles-video-348  "
                         playsinline=""
                       />
                     </div>
                     <div
-                      class="div-root-248"
+                      class="div-root-356"
                     >
                       <div
-                        class="div-root-249"
+                        class="div-root-357"
                       >
                         <div
-                          class="div-root-250"
+                          class="div-root-358"
                         >
                           <svg
                             viewBox="0 0 100 100"
@@ -115,13 +115,13 @@ Object {
         style="height: 100vh; width: 100%; background: gray;"
       >
         <div
-          class="MuiBox-root MuiBox-root-160"
+          class="MuiBox-root MuiBox-root-268"
         >
           <div
-            class="MuiBox-root MuiBox-root-161"
+            class="MuiBox-root MuiBox-root-269"
           >
             <div
-              class="div-root-162"
+              class="div-root-270"
             >
               <h5
                 class="MuiTypography-root MuiTypography-h5 MuiTypography-colorInherit MuiTypography-alignCenter"
@@ -141,7 +141,7 @@ Object {
                 class="MuiTypography-root MuiTypography-h6 MuiTypography-colorPrimary MuiTypography-alignCenter"
               >
                 <div
-                  class="MuiBox-root MuiBox-root-206 Styled(MuiBox)-root-205"
+                  class="MuiBox-root MuiBox-root-314 Styled(MuiBox)-root-313"
                   title="Copied!"
                 >
                   http://localhost/
@@ -150,34 +150,34 @@ Object {
             </div>
           </div>
           <div
-            class="div-root-207"
+            class="div-root-315"
           >
             <div
-              class="MuiPaper-root MuiCard-root WithStyles(ForwardRef(Card))-root-208 WithStyles(ForwardRef(Card))-root-209 MuiPaper-elevation10 MuiPaper-rounded"
+              class="MuiPaper-root MuiCard-root WithStyles(ForwardRef(Card))-root-316 WithStyles(ForwardRef(Card))-root-317 MuiPaper-elevation10 MuiPaper-rounded"
             >
               <div
-                class="MuiBox-root MuiBox-root-239"
+                class="MuiBox-root MuiBox-root-347"
               >
                 <div
-                  class="div-root-246"
+                  class="div-root-354"
                 >
                   <div
-                    class="div-root-247"
+                    class="div-root-355"
                   >
                     <video
                       autoplay=""
-                      class="makeStyles-mirroredVideo-241 makeStyles-video-240  "
+                      class="makeStyles-mirroredVideo-349 makeStyles-video-348  "
                       playsinline=""
                     />
                   </div>
                   <div
-                    class="div-root-248"
+                    class="div-root-356"
                   >
                     <div
-                      class="div-root-249"
+                      class="div-root-357"
                     >
                       <div
-                        class="div-root-250"
+                        class="div-root-358"
                       >
                         <svg
                           viewBox="0 0 100 100"
@@ -277,17 +277,17 @@ Object {
           style="height: 100vh; width: 100%; background: rgb(30, 31, 35);"
         >
           <div
-            class="div-root-255"
+            class="div-root-363"
           >
             <div
-              class="div-root-256"
+              class="div-root-364"
             />
             <div
-              class="div-root-257"
+              class="div-root-365"
             >
               <form>
                 <input
-                  class="input-root-258"
+                  class="input-root-366"
                   value=""
                 />
               </form>
@@ -303,17 +303,17 @@ Object {
         style="height: 100vh; width: 100%; background: rgb(30, 31, 35);"
       >
         <div
-          class="div-root-255"
+          class="div-root-363"
         >
           <div
-            class="div-root-256"
+            class="div-root-364"
           />
           <div
-            class="div-root-257"
+            class="div-root-365"
           >
             <form>
               <input
-                class="input-root-258"
+                class="input-root-366"
                 value=""
               />
             </form>
@@ -383,36 +383,36 @@ Object {
     <div>
       <div>
         <div
-          class="MuiBox-root MuiBox-root-274"
+          class="MuiBox-root MuiBox-root-382"
         >
           <div
-            class="MuiBox-root MuiBox-root-275"
+            class="MuiBox-root MuiBox-root-383"
           >
             <div
-              class="MuiBox-root MuiBox-root-276"
+              class="MuiBox-root MuiBox-root-384"
             >
               <div
-                class="MuiBox-root MuiBox-root-279 Styled(MuiBox)-root-277 Styled(MuiBox)-root-278"
+                class="MuiBox-root MuiBox-root-387 Styled(MuiBox)-root-385 Styled(MuiBox)-root-386"
               >
                 <div
-                  class="MuiBox-root MuiBox-root-280"
+                  class="MuiBox-root MuiBox-root-388"
                 >
                   hi
                 </div>
               </div>
               <div
-                class="MuiBox-root MuiBox-root-281"
+                class="MuiBox-root MuiBox-root-389"
               >
                 <div
-                  class="div-root-282 div-root-283"
+                  class="div-root-390 div-root-391"
                   width="5"
                 />
               </div>
               <div
-                class="MuiBox-root MuiBox-root-285 Styled(MuiBox)-root-277 Styled(MuiBox)-root-284"
+                class="MuiBox-root MuiBox-root-393 Styled(MuiBox)-root-385 Styled(MuiBox)-root-392"
               >
                 <div
-                  class="MuiBox-root MuiBox-root-286"
+                  class="MuiBox-root MuiBox-root-394"
                 >
                   hi
                 </div>
@@ -426,36 +426,36 @@ Object {
   "container": <div>
     <div>
       <div
-        class="MuiBox-root MuiBox-root-274"
+        class="MuiBox-root MuiBox-root-382"
       >
         <div
-          class="MuiBox-root MuiBox-root-275"
+          class="MuiBox-root MuiBox-root-383"
         >
           <div
-            class="MuiBox-root MuiBox-root-276"
+            class="MuiBox-root MuiBox-root-384"
           >
             <div
-              class="MuiBox-root MuiBox-root-279 Styled(MuiBox)-root-277 Styled(MuiBox)-root-278"
+              class="MuiBox-root MuiBox-root-387 Styled(MuiBox)-root-385 Styled(MuiBox)-root-386"
             >
               <div
-                class="MuiBox-root MuiBox-root-280"
+                class="MuiBox-root MuiBox-root-388"
               >
                 hi
               </div>
             </div>
             <div
-              class="MuiBox-root MuiBox-root-281"
+              class="MuiBox-root MuiBox-root-389"
             >
               <div
-                class="div-root-282 div-root-283"
+                class="div-root-390 div-root-391"
                 width="5"
               />
             </div>
             <div
-              class="MuiBox-root MuiBox-root-285 Styled(MuiBox)-root-277 Styled(MuiBox)-root-284"
+              class="MuiBox-root MuiBox-root-393 Styled(MuiBox)-root-385 Styled(MuiBox)-root-392"
             >
               <div
-                class="MuiBox-root MuiBox-root-286"
+                class="MuiBox-root MuiBox-root-394"
               >
                 hi
               </div>
@@ -564,6 +564,213 @@ Object {
           >
             Go Home
           </a>
+        </div>
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`Storyshots Group/ActivityTabs Default 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div>
+        <div
+          class="MuiTabs-root MuiTabs-vertical"
+        >
+          <div
+            class="MuiTabs-scroller MuiTabs-fixed"
+            style="overflow: hidden;"
+          >
+            <div
+              class="MuiTabs-flexContainer MuiTabs-flexContainerVertical"
+              role="tablist"
+            >
+              <button
+                aria-controls="scrollable-force-tabpanel-0"
+                aria-label="Basic Video"
+                aria-selected="true"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary Mui-selected"
+                id="scrollable-force-tab-0"
+                role="tab"
+                style="min-width: 50px; width: 100%; padding: 16px;"
+                tabindex="0"
+                title="Basic Video"
+                type="button"
+              >
+                <span
+                  class="MuiTab-wrapper"
+                >
+                  <span
+                    aria-hidden="true"
+                    class="material-icons MuiIcon-root"
+                  >
+                    video_call
+                  </span>
+                </span>
+                <span
+                  class="MuiTouchRipple-root"
+                />
+              </button>
+              <button
+                aria-controls="scrollable-force-tabpanel-1"
+                aria-label="Browse Together"
+                aria-selected="false"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary"
+                id="scrollable-force-tab-1"
+                role="tab"
+                style="min-width: 50px; width: 100%; padding: 16px;"
+                tabindex="-1"
+                title="Browse Together"
+                type="button"
+              >
+                <span
+                  class="MuiTab-wrapper"
+                >
+                  <span
+                    aria-hidden="true"
+                    class="material-icons MuiIcon-root"
+                  >
+                    web
+                  </span>
+                </span>
+                <span
+                  class="MuiTouchRipple-root"
+                />
+              </button>
+            </div>
+            <span
+              class="PrivateTabIndicator-root-171 PrivateTabIndicator-colorPrimary-172 MuiTabs-indicator makeStyles-tabsIndicator-116 PrivateTabIndicator-vertical-174"
+              style="top: 0px; height: 0px;"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div>
+      <div
+        class="MuiTabs-root MuiTabs-vertical"
+      >
+        <div
+          class="MuiTabs-scroller MuiTabs-fixed"
+          style="overflow: hidden;"
+        >
+          <div
+            class="MuiTabs-flexContainer MuiTabs-flexContainerVertical"
+            role="tablist"
+          >
+            <button
+              aria-controls="scrollable-force-tabpanel-0"
+              aria-label="Basic Video"
+              aria-selected="true"
+              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary Mui-selected"
+              id="scrollable-force-tab-0"
+              role="tab"
+              style="min-width: 50px; width: 100%; padding: 16px;"
+              tabindex="0"
+              title="Basic Video"
+              type="button"
+            >
+              <span
+                class="MuiTab-wrapper"
+              >
+                <span
+                  aria-hidden="true"
+                  class="material-icons MuiIcon-root"
+                >
+                  video_call
+                </span>
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </button>
+            <button
+              aria-controls="scrollable-force-tabpanel-1"
+              aria-label="Browse Together"
+              aria-selected="false"
+              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary"
+              id="scrollable-force-tab-1"
+              role="tab"
+              style="min-width: 50px; width: 100%; padding: 16px;"
+              tabindex="-1"
+              title="Browse Together"
+              type="button"
+            >
+              <span
+                class="MuiTab-wrapper"
+              >
+                <span
+                  aria-hidden="true"
+                  class="material-icons MuiIcon-root"
+                >
+                  web
+                </span>
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </button>
+          </div>
+          <span
+            class="PrivateTabIndicator-root-171 PrivateTabIndicator-colorPrimary-172 MuiTabs-indicator makeStyles-tabsIndicator-116 PrivateTabIndicator-vertical-174"
+            style="top: 0px; height: 0px;"
+          />
         </div>
       </div>
     </div>

--- a/packages/client/src/components/Group/components/ActivityTabs/ActivityTabs.stories.tsx
+++ b/packages/client/src/components/Group/components/ActivityTabs/ActivityTabs.stories.tsx
@@ -1,0 +1,36 @@
+import { action } from '@storybook/addon-actions';
+import { number, object, text } from '@storybook/addon-knobs';
+import React from 'react';
+
+import ActivityTabs from './ActivityTabs';
+
+export default {
+  title: 'Group/ActivityTabs',
+};
+
+export const Default = () => {
+  const activeActivityIndex = number('props.activeActivityIndex', 0);
+  const activeViewId = text('props.activeViewId', 'activeViewId');
+  const activities = object('props.activities', [
+    {
+      id: '0',
+      name: 'Basic Video',
+      icon: 'video_call',
+    },
+    {
+      id: '1',
+      name: 'Browse Together',
+      icon: 'web',
+    },
+  ]);
+  const setActiveViewId = action('props.setActiveViewId');
+
+  return (
+    <ActivityTabs
+      activeActivityIndex={activeActivityIndex}
+      activeViewId={activeViewId}
+      activities={activities}
+      setActiveViewId={setActiveViewId}
+    />
+  );
+};

--- a/packages/client/src/components/Group/components/ActivityTabs/ActivityTabs.test.tsx
+++ b/packages/client/src/components/Group/components/ActivityTabs/ActivityTabs.test.tsx
@@ -1,0 +1,37 @@
+import { fireEvent, render } from '@testing-library/react';
+import React from 'react';
+
+import ActivityTabs from './ActivityTabs';
+
+describe('<ActivityTabs />', () => {
+  test('clicking on a tab fires setActiveViewId with the right id', () => {
+    const setActiveViewId = jest.fn();
+    const { getByText } = render(
+      <ActivityTabs
+        activeActivityIndex={0}
+        activeViewId="foo"
+        activities={[
+          {
+            id: 'activityOne',
+            name: 'acivitity one',
+            icon: 'video_call',
+          },
+          {
+            id: 'activityTwo',
+            name: 'acivitity two',
+            icon: 'web',
+          },
+        ]}
+        setActiveViewId={setActiveViewId}
+      />,
+    );
+    // relies on icon backfill text, which is icon name
+    fireEvent.click(getByText('video_call'));
+    expect(setActiveViewId).toHaveBeenCalledTimes(1);
+    expect(setActiveViewId).toHaveBeenCalledWith('activityOne');
+    setActiveViewId.mockClear();
+    fireEvent.click(getByText('web'));
+    expect(setActiveViewId).toHaveBeenCalledTimes(1);
+    expect(setActiveViewId).toHaveBeenCalledWith('activityTwo');
+  });
+});

--- a/packages/client/src/components/Group/components/ActivityTabs/ActivityTabs.tsx
+++ b/packages/client/src/components/Group/components/ActivityTabs/ActivityTabs.tsx
@@ -9,8 +9,6 @@ import {
 } from '@material-ui/core';
 import React from 'react';
 
-import useActivities from '../../../../lib/hooks/useActivities';
-
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     tabsIndicator: {
@@ -28,60 +26,42 @@ function a11yProps(index: number | string) {
 }
 
 interface Props {
+  activeActivityIndex: number;
   activeViewId: string;
+  activities: {
+    icon: string;
+    id: string;
+    name: string;
+  }[];
   setActiveViewId: (id: string) => void;
 }
 
 export default function ActivityTabs(props: Props) {
-  const { data, loading } = useActivities();
   const classes = useStyles();
-
-  if (loading) {
-    return null;
-  }
-  const builtInActivities = [
-    {
-      id: '0',
-      name: 'Basic Video',
-      icon: 'video_call',
-    },
-    {
-      id: '1',
-      name: 'Browse Together',
-      icon: 'web',
-    },
-  ];
-
-  const activities = [...builtInActivities, ...data];
-  const activeActivityIndex = activities.findIndex(
-    activity => activity.id === props.activeViewId,
-  );
 
   return (
     <Tabs
-      value={activeActivityIndex}
+      classes={{ indicator: classes.tabsIndicator }}
+      indicatorColor="primary"
       onChange={(event, value) => {
         props.setActiveViewId(`${value}`);
       }}
       orientation="vertical"
-      indicatorColor="primary"
       textColor="primary"
-      classes={{
-        indicator: classes.tabsIndicator,
-      }}
+      value={props.activeActivityIndex}
     >
-      {activities.map(activity => {
+      {props.activities.map(activity => {
         return (
           <Tooltip
-            key={activity.id}
-            title={activity.name}
             aria-label={activity.name}
+            key={activity.id}
             placement="left"
+            title={activity.name}
           >
             <Tab
-              style={{ minWidth: 50, width: '100%', padding: 16 }}
               aria-label={activity.name}
               icon={<Icon>{activity.icon}</Icon>}
+              style={{ minWidth: 50, width: '100%', padding: 16 }}
               value={activity.id}
               {...a11yProps(activity.id)}
             />

--- a/packages/client/src/components/Group/components/ActivityTabs/ActivityTabsContainer.tsx
+++ b/packages/client/src/components/Group/components/ActivityTabs/ActivityTabsContainer.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+import useActivities from '../../../../lib/hooks/useActivities';
+import ActivityTabs from './ActivityTabs';
+
+interface Props {
+  activeViewId: string;
+  setActiveViewId: (id: string) => void;
+}
+
+export default function ActivityTabsContainer(props: Props) {
+  const { data, loading } = useActivities();
+
+  if (loading) {
+    return null;
+  }
+  const builtInActivities = [
+    {
+      id: '0',
+      name: 'Basic Video',
+      icon: 'video_call',
+    },
+    {
+      id: '1',
+      name: 'Browse Together',
+      icon: 'web',
+    },
+  ];
+
+  const activities = [...builtInActivities, ...data];
+  const activeActivityIndex = activities.findIndex(
+    activity => activity.id === props.activeViewId,
+  );
+
+  return (
+    <ActivityTabs
+      activeActivityIndex={activeActivityIndex}
+      activeViewId={props.activeViewId}
+      activities={activities}
+      setActiveViewId={props.setActiveViewId}
+    />
+  );
+}

--- a/packages/client/src/components/Group/components/ActivityTabs/ActivityTabsContainer.tsx
+++ b/packages/client/src/components/Group/components/ActivityTabs/ActivityTabsContainer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { builtInActivities } from '../../../../constants';
 import useActivities from '../../../../lib/hooks/useActivities';
 import ActivityTabs from './ActivityTabs';
 
@@ -10,22 +11,7 @@ interface Props {
 
 export default function ActivityTabsContainer(props: Props) {
   const { data, loading } = useActivities();
-
-  if (loading) {
-    return null;
-  }
-  const builtInActivities = [
-    {
-      id: '0',
-      name: 'Basic Video',
-      icon: 'video_call',
-    },
-    {
-      id: '1',
-      name: 'Browse Together',
-      icon: 'web',
-    },
-  ];
+  if (loading) return null;
 
   const activities = [...builtInActivities, ...data];
   const activeActivityIndex = activities.findIndex(

--- a/packages/client/src/components/Group/components/ActivityTabs/ActivityTabsContainer.tsx
+++ b/packages/client/src/components/Group/components/ActivityTabs/ActivityTabsContainer.tsx
@@ -1,8 +1,20 @@
 import React from 'react';
 
-import { builtInActivities } from '../../../../constants';
 import useActivities from '../../../../lib/hooks/useActivities';
 import ActivityTabs from './ActivityTabs';
+
+const BUILT_IN_ACTIVITIES = [
+  {
+    id: '0',
+    name: 'Basic Video',
+    icon: 'video_call',
+  },
+  {
+    id: '1',
+    name: 'Browse Together',
+    icon: 'web',
+  },
+];
 
 interface Props {
   activeViewId: string;
@@ -13,7 +25,7 @@ export default function ActivityTabsContainer(props: Props) {
   const { data, loading } = useActivities();
   if (loading) return null;
 
-  const activities = [...builtInActivities, ...data];
+  const activities = [...BUILT_IN_ACTIVITIES, ...data];
   const activeActivityIndex = activities.findIndex(
     activity => activity.id === props.activeViewId,
   );

--- a/packages/client/src/components/Group/components/ActivityTabs/index.ts
+++ b/packages/client/src/components/Group/components/ActivityTabs/index.ts
@@ -1,1 +1,1 @@
-export { default } from './ActivityTabs';
+export { default } from './ActivityTabsContainer';

--- a/packages/client/src/constants.ts
+++ b/packages/client/src/constants.ts
@@ -11,5 +11,18 @@ export const appConfig = {
   sentryDsn: process.env.REACT_APP_SENTRY_DSN,
 };
 
+export const builtInActivities = [
+  {
+    id: '0',
+    name: 'Basic Video',
+    icon: 'video_call',
+  },
+  {
+    id: '1',
+    name: 'Browse Together',
+    icon: 'web',
+  },
+];
+
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 export const noop = (...args: any[]): any => {};

--- a/packages/client/src/constants.ts
+++ b/packages/client/src/constants.ts
@@ -11,18 +11,5 @@ export const appConfig = {
   sentryDsn: process.env.REACT_APP_SENTRY_DSN,
 };
 
-export const builtInActivities = [
-  {
-    id: '0',
-    name: 'Basic Video',
-    icon: 'video_call',
-  },
-  {
-    id: '1',
-    name: 'Browse Together',
-    icon: 'web',
-  },
-];
-
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 export const noop = (...args: any[]): any => {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2194,7 +2194,7 @@
   dependencies:
     type-detect "4.0.8"
 
-"@storybook/addon-actions@^5.3.0":
+"@storybook/addon-actions@^5.3.18":
   version "5.3.18"
   resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-5.3.18.tgz#e3e3b1475cebc9bdd2d563822fba9ac662b2601a"
   integrity sha512-jdBVCcfyWin274Lkwg5cL+1fJ651NCuIWxuJVsmHQtIl2xTjf2MyoMoKQZNdt4xtE+W9w+rS4bYt04elrizThg==


### PR DESCRIPTION
* fixes storybook styling with material ui (cssbaseline needed to come before theme, and added icons css)
* adds stories + integration tests to display side of activity tabs
* separates out container logic for activity tabs
* moves built-in activities => constants